### PR TITLE
Add botan variant

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,19 +6,30 @@
 		"Oleh Havrys",
 		"Sergey Buth"
 	],
-	"dependencies" : {
-		"openssl": "~>1.1.4+1.0.1g"
-	},
 	
 	"configurations": [
     	{
       		"name": "library",
-      		"targetType": "library"
+      		"targetType": "library",
+			"dependencies" : {
+				"openssl": "~>1.1.4+1.0.1g"
+			}
     	},
     	{
       		"name": "unittest",
       		"mainSourceFile": "source/app.d",
-      		"targetType": "executable"
-    	}
+      		"targetType": "executable",
+			"dependencies" : {
+				"openssl": "~>1.1.4+1.0.1g"
+			}
+    	},
+	    {
+			"name": "botan",
+			"targetType": "library",
+			"dependencies" : {
+				"botan": "~>1.12.0"
+			},
+			"versions": ["UseBotan"],
+		}
   	]
 }

--- a/source/jwtd/jwt_botan.d
+++ b/source/jwtd/jwt_botan.d
@@ -1,0 +1,75 @@
+﻿module jwtd.jwt_botan;
+
+import jwtd.jwt;
+import botan.mac.hmac;
+import botan.hash.hash;
+import botan.hash.sha2_32 : SHA256;
+import botan.hash.sha2_64 : SHA384, SHA512;
+import memutils.unique;
+
+version (UseBotan) {
+	string sign(string msg, string key, JWTAlgorithm algo = JWTAlgorithm.HS256) {
+		ubyte[] sign;
+
+		void sign_hs(HashFunction hashFun) {
+			Unique!HMAC hmac = new HMAC(hashFun);
+			
+			hmac.setKey(cast(const(ubyte)*)key.ptr, key.length);
+			hmac.update(msg);
+			sign = hmac.finished()[].dup;
+		}
+			
+		switch(algo) {
+			case JWTAlgorithm.NONE: {
+				break;
+			}
+			case JWTAlgorithm.HS256: {
+				Unique!SHA256 hash = new SHA256();
+				sign_hs(*hash);
+				break;
+			}
+			case JWTAlgorithm.HS384: {
+				Unique!SHA384 hash = new SHA384();
+				sign_hs(*hash);
+				break;
+			}
+			case JWTAlgorithm.HS512: {
+				Unique!SHA512 hash = new SHA512();
+				sign_hs(*hash);
+				break;
+			}
+			case JWTAlgorithm.RS256:
+			case JWTAlgorithm.RS384:
+			case JWTAlgorithm.RS512:
+			case JWTAlgorithm.ES256:
+			case JWTAlgorithm.ES384:
+			case JWTAlgorithm.ES512:
+			default:
+				throw new SignException("Wrong algorithm");
+		}
+		
+		return cast(string)sign;
+	}
+
+	bool verifySignature(string signature, string signing_input, string key, JWTAlgorithm algo = JWTAlgorithm.HS256) {
+		
+		switch(algo) {
+			case JWTAlgorithm.NONE: {
+				return true;
+			}
+			case JWTAlgorithm.HS256:
+			case JWTAlgorithm.HS384:
+			case JWTAlgorithm.HS512: {
+				return signature == sign(signing_input, key, algo);
+			}
+			case JWTAlgorithm.RS256:
+			case JWTAlgorithm.RS384:
+			case JWTAlgorithm.RS512:
+			case JWTAlgorithm.ES256:
+			case JWTAlgorithm.ES384:
+			case JWTAlgorithm.ES512:
+			default:
+				throw new VerifyException("Wrong algorithm.");
+		}
+	}
+}


### PR DESCRIPTION
Hi, I'm in need to use JWT within vibe.d and would like to make it possible to use it also with native Botan library[0].
I could roll my own variant, but maybe it would be better to stay with one jwtd in code.dlang.org with both libraries backend possible so user can simply choose one of them.

I've made this PR to see if you are interested so just HS256, HS384 and HS512 are implemented with Botan as of yet.

[0] https://github.com/etcimon/botan
