### PR TITLE
Added RSA algorithms for Botan

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ D implementation of [JSON Web Token](http://jwt.io/).
 - HS256
 - HS384
 - HS512
+- RS256
+- RS384
+- RS512
+
+**NOTE** - Botan does not support private keys in PKCS#1 format so it needs to be supplied with PKCS#8
 
 ## Installation
 

--- a/source/app.d
+++ b/source/app.d
@@ -5,6 +5,8 @@ void main() {
 		import std.stdio;
 
 		version(UseBotan) {
+			import botan.libstate.init;
+			LibraryInitializer init;
 			writeln("Encryption library: Botan.");
 		}
 

--- a/source/jwtd/jwt.d
+++ b/source/jwtd/jwt.d
@@ -263,12 +263,13 @@ EOS";
 	// rs256
 
 	string rs256Token = encode(["language": "D"], private256, JWTAlgorithm.RS256);
-    import std.stdio; writeln(rs256Token);
 	assert(rs256Token == "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJsYW5ndWFnZSI6IkQifQ.BYpRNUNsho1Yquq7Uolp31K2Ng90h0hRlMV6J6d9WSSIYf7s2MBX2xgDlBuHtB-Yb9dkbkfdxqjYCQdWejiMc_II6dn72ZSBwBCyWdPPRNbTRA2DNlsoKFBS5WMp7iYordfD9KE0LowK61n_Z7AHNAiOop5Ka1xTKH8cqEo8s3ItgoxZt8mzAfhIYNogGown6sYytqg1I72UHsEX9KAuP7sCxCbxZ9cSVg2f4afEuwwo08AdG3hW_LXhT7VD-EweDmvF2JLAyf1_rW66PMgiZZCLQ6kf2hQRsa56xRDmo5qC98wDseBHx9f3PsTsracTKojwQUdezDmbHv90vCt-Iw");
 	assert(verify(rs256Token, public256));
 
-//	// es256
-//
-//	string es256Token = encode(["language": "D"], es256_key, JWTAlgorithm.ES256);
-//	assert(verify(es256Token, es256_key));
+	version (UseOpenSSL) {
+	// es256
+
+	string es256Token = encode(["language": "D"], es256_key, JWTAlgorithm.ES256);
+	assert(verify(es256Token, es256_key));
+	}
 }

--- a/source/jwtd/jwt.d
+++ b/source/jwtd/jwt.d
@@ -156,7 +156,41 @@ string urlsafeB64Decode(string inp) {
 }
 
 unittest {
-	string private256 = q"EOS
+
+	version(UseBotan) {
+		string private256 = q"EOS
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCr5790wT0yuSWn
+yG+HOqgCr4JYLI4dCuygyHK6qJ5OvdB9RG1Rj531VXQ2F+BJGtvOxgah05X6y6jm
+Ov/OL/NMN8S8MWMhXPYd9/NPOuJD+ricXalmp9pL5y2qrrAhrkTTlptbiYrq/PVe
+e6qLXC7wp9RmMQDlTxlrkykzgTo/rbjMzP43wL2TovI2ATc+v15T63uhtk1mdAIs
+EXiDljFhD6alW8+tHlZmF9EJERPfCE8LSRHHLt/V0HGnGr3Pq519Q/lL9TJSqWJ4
+x4Lpjz715qDsN//8aEdvwyVRSACVNeceE4t/WVQSqVZZwfElz2y1uAyw8I6W+S6t
+AJXfoc5JAgMBAAECggEAW2TjwlQ2kDAlV/XVbcT+rCbZmr1ddQ1ozvajIKAjQmPi
+Y6cso69CYLvlBBlfkh5ofJ+FySWv2F3M11LIy7tsk7oWq6NqO8OryjUYM6hvwYqb
++e5F8SEOi0pGWjdzxwRa7U9mG52dsN96KJiBDISfJC1mXEpzWnbaYfokbpCnAlEf
+mJrFoJwBj7PFcN/U0lyou2UJB8/JwtPx89Y4VVSu1SdQbwMSbxXyvWgeHpSwJCyt
+BsHbSpYl2JDGv1bauLDp478Scr2+xdepEbOtfK5oTbNl7OBRG2GBViI+l746sPJ5
+RZ2mfVSiHQ+sXM+0tUSNikyZPlOkGRuEoFL/it7TnQKBgQDgmY7A5eD32R526zLl
+yCGwRcjd8399RoCPad8/euMlosSIw5Kb+Y3wIMZ2g4peaGTvDW6ne/YAwATIpsh2
+swBVz+b0aIo0+6I42Udlb/FAYGKX0xjzg2FZSzCDR+DvS7g6el/JiduucM+34Gko
+g7SflbpPMOziIWiBOVqTLkHvtwKBgQDD8D+NkEjHJhQmB7G3tqiH9Zjd3+AeYDKK
+aTSBrBCzMhAXjbjwcY+bdlMvwWhcAwI0UQC3Tew25siHJtLpsfP6CLY/+81QYavD
+dt1dbiB5ahpkbB8OYqDQH+rvI4fcyEnWhKGaEibI3VAY+nd9y11prHvwmcZOblpc
+gEBzV34x/wKBgEBurQ5XpEdWCTBSXwKefFOmYW6S+UMGI8GAvOPoLBvS6xDVEk0e
+tYJq1KSRLfPRfQs7TkBMBpHGhFjPx/iNd44mm3oIN4Xlnm8ynhHSoGI4hHBLxf+t
+9BJ6yIsQ5s2falWUX8BghR4xDNYSUfimd/3EJXOsdHiW3vUbcAmDHrVXAoGBAKtp
+IOACSnjWSige8Q0r4XHXnFz1/oX0WCKX+NQ8J/vsHwHL/O90GVLCh/GuPFLKWwJT
+ntG9fJlm+iSqBTdmc27Ycj+1VB8u4unDsdKLhiNRfDdAE0ctZ0vLsGZ2aePu4BGn
+xAwaNw3f9rNzYleNMnJA78hDbqWsiqaDmF6POxoXAoGAEsj9YmS8/kgoJITjNII6
+04wowxcMS/eUffQ7bPizLDYRPQQ0CKhAPC+vVz+wWzJSgHCcuYmHBjG6940Ethg1
++AsWwkm893VF6r6eLjt7byoqfaJEbsZm9y2mQi353PHIChq7CynEQSI+kaPP3V28
+FIb2otyo1D4EXhfhvIH2K1A=
+-----END PRIVATE KEY-----
+EOS";
+	}
+	else {
+		string private256 = q"EOS
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAq+e/dME9Mrklp8hvhzqoAq+CWCyOHQrsoMhyuqieTr3QfURt
 UY+d9VV0NhfgSRrbzsYGodOV+suo5jr/zi/zTDfEvDFjIVz2HffzTzriQ/q4nF2p
@@ -185,6 +219,7 @@ r1c/sFsyUoBwnLmJhwYxuveNBLYYNfgLFsJJvPd1Req+ni47e28qKn2iRG7GZvct
 pkIt+dzxyAoauwspxEEiPpGjz91dvBSG9qLcqNQ+BF4X4byB9itQ
 -----END RSA PRIVATE KEY-----
 EOS";
+	}
 
 	string public256 = q"EOS
 -----BEGIN PUBLIC KEY-----
@@ -225,19 +260,15 @@ EOS";
 	assert(hs512Token == "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJsYW5ndWFnZSI6IkQifQ.tDRXngYs15t6Q-9AortMxXNfvTgVjaQGD9VTlwL3JD6Xxab8ass2ekCoom8uOiRdpZ772ajLQD42RXMuALct1Q");
 	assert(verify(hs512Token, hs_secret));
 
+	// rs256
 
-	version (UseOpenSSL) {
+	string rs256Token = encode(["language": "D"], private256, JWTAlgorithm.RS256);
+    import std.stdio; writeln(rs256Token);
+	assert(rs256Token == "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJsYW5ndWFnZSI6IkQifQ.BYpRNUNsho1Yquq7Uolp31K2Ng90h0hRlMV6J6d9WSSIYf7s2MBX2xgDlBuHtB-Yb9dkbkfdxqjYCQdWejiMc_II6dn72ZSBwBCyWdPPRNbTRA2DNlsoKFBS5WMp7iYordfD9KE0LowK61n_Z7AHNAiOop5Ka1xTKH8cqEo8s3ItgoxZt8mzAfhIYNogGown6sYytqg1I72UHsEX9KAuP7sCxCbxZ9cSVg2f4afEuwwo08AdG3hW_LXhT7VD-EweDmvF2JLAyf1_rW66PMgiZZCLQ6kf2hQRsa56xRDmo5qC98wDseBHx9f3PsTsracTKojwQUdezDmbHv90vCt-Iw");
+	assert(verify(rs256Token, public256));
 
-		// rs256
-
-		string rs256Token = encode(["language": "D"], private256, JWTAlgorithm.RS256);
-		assert(rs256Token == "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJsYW5ndWFnZSI6IkQifQ.BYpRNUNsho1Yquq7Uolp31K2Ng90h0hRlMV6J6d9WSSIYf7s2MBX2xgDlBuHtB-Yb9dkbkfdxqjYCQdWejiMc_II6dn72ZSBwBCyWdPPRNbTRA2DNlsoKFBS5WMp7iYordfD9KE0LowK61n_Z7AHNAiOop5Ka1xTKH8cqEo8s3ItgoxZt8mzAfhIYNogGown6sYytqg1I72UHsEX9KAuP7sCxCbxZ9cSVg2f4afEuwwo08AdG3hW_LXhT7VD-EweDmvF2JLAyf1_rW66PMgiZZCLQ6kf2hQRsa56xRDmo5qC98wDseBHx9f3PsTsracTKojwQUdezDmbHv90vCt-Iw");
-		assert(verify(rs256Token, public256));
-
-		// es256
-
-		string es256Token = encode(["language": "D"], es256_key, JWTAlgorithm.ES256);
-		assert(verify(es256Token, es256_key));
-
-	}
+//	// es256
+//
+//	string es256Token = encode(["language": "D"], es256_key, JWTAlgorithm.ES256);
+//	assert(verify(es256Token, es256_key));
 }

--- a/source/jwtd/jwt_botan.d
+++ b/source/jwtd/jwt_botan.d
@@ -21,6 +21,21 @@ version (UseBotan) {
 			sign = hmac.finished()[].dup;
 		}
 
+//		void sign_rs(ubyte* hash, int type, uint len, uint signLen) {
+//			sign = new ubyte[len];
+//
+//			RSA* rsa_private = RSA_new();
+//			BIO* bpo = BIO_new_mem_buf(cast(char*)key.ptr, -1);
+//			if(bpo is null)
+//				throw new Exception("Can't load the key.");
+//			PEM_read_bio_RSAPrivateKey(bpo, &rsa_private, null, null);
+//			BIO_free(bpo);
+//			if(rsa_private is null)
+//				throw new Exception("Can't create RSA key.");
+//			RSA_sign(type, hash, signLen, sign.ptr, &signLen, rsa_private);
+//			RSA_free(rsa_private);
+//		}
+
 		switch(algo) {
 			case JWTAlgorithm.NONE: {
 				break;
@@ -41,6 +56,21 @@ version (UseBotan) {
 				break;
 			}
 			case JWTAlgorithm.RS256:
+				import botan.pubkey.algo.rsa;
+				import botan.rng.auto_rng;
+				import botan.filters.data_src;
+                
+                Unique!SHA256 hash = new SHA256();
+                hash.update(msg);
+
+				Unique!AutoSeededRNG rng = new AutoSeededRNG;
+				auto privKey = loadKey(cast(DataSource)DataSourceMemory(key), *rng);
+                auto signer = PKSigner(privKey, "EMSA4(SHA-256)");
+                auto res = signer.signMessage(cast(const(ubyte)*)msg.ptr, msg.length, *rng);
+                //auto res = signer.signMessage(hash.finished(), *rng);
+                sign = res[];
+				//sign_rs(hash.ptr, NID_sha256, 256, SHA256_DIGEST_LENGTH);
+				break;
 			case JWTAlgorithm.RS384:
 			case JWTAlgorithm.RS512:
 			case JWTAlgorithm.ES256:

--- a/source/jwtd/jwt_botan.d
+++ b/source/jwtd/jwt_botan.d
@@ -9,9 +9,6 @@ version (UseBotan) {
 	import botan.hash.hash;
 	import botan.hash.sha2_32 : SHA256;
 	import botan.hash.sha2_64 : SHA384, SHA512;
-	import botan.pubkey.algo.rsa;
-	import botan.filters.data_src;
-	import x509 = botan.pubkey.x509_key;
 	import memutils.unique;
 
 	string sign(string msg, string key, JWTAlgorithm algo = JWTAlgorithm.HS256) {
@@ -23,6 +20,25 @@ version (UseBotan) {
 			hmac.setKey(cast(const(ubyte)*)key.ptr, key.length);
 			hmac.update(msg);
 			sign = hmac.finished()[].dup;
+		}
+
+		void sign_rs(string emsaName) {
+			import botan.filters.data_src;
+			import x509 = botan.pubkey.x509_key;
+			import botan.pubkey.algo.rsa;
+
+			Unique!AutoSeededRNG rng = new AutoSeededRNG;
+			auto privKey = loadKey(cast(DataSource)DataSourceMemory(key), *rng);
+			auto signer = PKSigner(privKey, emsaName);
+			sign = signer.signMessage(cast(const(ubyte)*)msg.ptr, msg.length, *rng)[].dup;
+
+			debug
+			{
+				auto verifier = PKVerifier(privKey, emsaName);
+				assert(verifier.verifyMessage(
+						cast(const(ubyte)*)msg.ptr, msg.length,
+						cast(const(ubyte)*)sign.ptr, sign.length));
+			}
 		}
 
 		switch(algo) {
@@ -45,18 +61,14 @@ version (UseBotan) {
 				break;
 			}
 			case JWTAlgorithm.RS256:
-				Unique!AutoSeededRNG rng = new AutoSeededRNG;
-				auto privKey = loadKey(cast(DataSource)DataSourceMemory(key), *rng);
-				auto signer = PKSigner(privKey, "EMSA3(SHA-256)");
-				sign = signer.signMessage(cast(const(ubyte)*)msg.ptr, msg.length, *rng)[];
-
-				auto verifier = PKVerifier(privKey, "EMSA3(SHA-256)");
-				assert(verifier.verifyMessage(
-					cast(const(ubyte)*)msg.ptr, msg.length,
-					cast(const(ubyte)*)sign.ptr, sign.length));
+				sign_rs("EMSA3(SHA-256)");
 				break;
 			case JWTAlgorithm.RS384:
+				sign_rs("EMSA3(SHA-384)");
+				break;
 			case JWTAlgorithm.RS512:
+				sign_rs("EMSA3(SHA-512)");
+				break;
 			case JWTAlgorithm.ES256:
 			case JWTAlgorithm.ES384:
 			case JWTAlgorithm.ES512:
@@ -69,23 +81,31 @@ version (UseBotan) {
 
 	bool verifySignature(string signature, string signing_input, string key, JWTAlgorithm algo = JWTAlgorithm.HS256) {
 
+		bool verify_rs(string emsaName) {
+			import x509 = botan.pubkey.x509_key;
+			import botan.pubkey.algo.rsa;
+			import botan.filters.data_src;
+
+			auto pubKey = x509.loadKey(cast(DataSource)DataSourceMemory(key));
+			auto verifier = PKVerifier(pubKey, emsaName);
+			return verifier.verifyMessage(
+				cast(const(ubyte)*)signing_input.ptr, signing_input.length,
+				cast(const(ubyte)*)signature.ptr, signature.length);
+		}
+
 		switch(algo) {
-			case JWTAlgorithm.NONE: {
+			case JWTAlgorithm.NONE:
 				return true;
-			}
 			case JWTAlgorithm.HS256:
 			case JWTAlgorithm.HS384:
-			case JWTAlgorithm.HS512: {
+			case JWTAlgorithm.HS512:
 				return signature == sign(signing_input, key, algo);
-			}
 			case JWTAlgorithm.RS256:
-				auto pubKey = x509.loadKey(cast(DataSource)DataSourceMemory(key));
-				auto verifier = PKVerifier(pubKey, "EMSA3(SHA-256)");
-				return verifier.verifyMessage(
-					cast(const(ubyte)*)signing_input.ptr, signing_input.length,
-					cast(const(ubyte)*)signature.ptr, signature.length);
+				return verify_rs("EMSA3(SHA-256)");
 			case JWTAlgorithm.RS384:
+				return verify_rs("EMSA3(SHA-384)");
 			case JWTAlgorithm.RS512:
+				return verify_rs("EMSA3(SHA-512)");
 			case JWTAlgorithm.ES256:
 			case JWTAlgorithm.ES384:
 			case JWTAlgorithm.ES512:


### PR DESCRIPTION
I've finally make it work.
Unfortunatelly Botan does not support PKCS#1 format private keys loading, so I had to convert the PK in unittest to PKCS#8 format.
Also added Botan library init to the app.d as per: https://github.com/etcimon/botan/wiki/Getting-Started

For the future, it would be nice to have a possibility to not pass a PK as a string to encode and verify methods but directly as a Botan specific structures and also to use its SecureVector to make the lib more secure to use.
