### PR TITLE
Avoid linker conflicts by using explicit module name

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -1,3 +1,4 @@
+module jwtd.app;
 import jwtd.jwt;
 
 unittest {


### PR DESCRIPTION
I had fixed the `main`, but forgot about the `ModuleInfo` conflict.