### PR TITLE
Add support for OpenSSL 1.1

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -18,6 +18,14 @@
 			"versions": ["UseOpenSSL"]
 		},
 		{
+			"name": "openssl-1.1",
+			"targetType": "library",
+			"dependencies" : {
+				"openssl": "~>1.1.4+1.0.1g"
+			},
+			"versions": ["UseOpenSSL", "OpenSSL11"]
+		},
+		{
 			"name": "botan",
 			"targetType": "library",
 			"dependencies" : {


### PR DESCRIPTION
OpenSSL 1.1 removed the HMAC_CTX_init and HMAC_CTX_cleanup functions.

This commit adds a new configuration openssl-1.1 (same name as vibe-d:tls) which uses the new replacement functions. Unfortunately using the openssl-1.1 binding (version 2 of the openssl package) seems to cause lots of version conflicts in larger projects. Vibe-d also seems to use the old bindings in its openssl-1.1 configuration for this reason.

Would be great if we can get this merged and released, as many distributions use openssl-1.1 nowadays.